### PR TITLE
Remove unused os import

### DIFF
--- a/generate_candidates.py
+++ b/generate_candidates.py
@@ -5,7 +5,6 @@ from typing import List, Optional
 from transformers import AutoTokenizer, AutoModelForCausalLM, pipeline
 from datasets import Dataset
 import torch
-import os
 
 import torch._dynamo
 torch._dynamo.config.cache_size_limit = 256


### PR DESCRIPTION
## Summary
- clean up unused `os` import in `generate_candidates.py`

## Testing
- `python -m py_compile generate_candidates.py generate_preference_dataset.py`


------
https://chatgpt.com/codex/tasks/task_e_685cd46cfce8832bbaa33a81d364c2d0