### PR TITLE
Fix grammar in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains utilities for working with the Empathetic Dialogue dataset.
 
-- `generate_preference_dataset.py` scores the original and candidate responses with `deepseek-ai/DeepSeek-R1-Distill-Llama-8B` to create a preference dataset named `LLMprefer.json` containing `prompt`, `chosen`, and `reject` field
+- `generate_preference_dataset.py` scores the original and candidate responses with `deepseek-ai/DeepSeek-R1-Distill-Llama-8B` to create a preference dataset named `LLMprefer.json` containing `prompt`, `chosen`, and `reject` fields
 
 
 This project contains utilities for generating candidate responses for the Empathetic Dialogues dataset using Hugging Face models. The main script `generate_candidates.py` reads a `train.json` file containing conversation prompts and outputs a list of model generated replies.


### PR DESCRIPTION
## Summary
- fix a typo in the README for the preference dataset description

## Testing
- `python -m py_compile generate_candidates.py generate_preference_dataset.py`


------
https://chatgpt.com/codex/tasks/task_e_685cd3e8f6fc832b9f7489025634d751