### PR TITLE
Improve candidate retry batching

### DIFF
--- a/generate_candidates.py
+++ b/generate_candidates.py
@@ -66,6 +66,8 @@ def sanitize_output(text: str) -> str:
     # Drop common prefixes or markup
     text = re.sub(r"(?i)^your response:\s*", "", text)
     text = re.sub(r"^#+\s*", "", text)
+    text = re.sub(r"(?i)^\*?\s*user:?\s*", "", text)
+    text = re.sub(r"(?i)^\*?\s*assistant:?\s*", "", text)
 
     # Remove bullet characters and repeated punctuation
     text = re.sub(r"^[\-*]\s+", "", text, flags=re.MULTILINE)
@@ -202,6 +204,7 @@ def generate_responses(
 
         output_iter = _iter()
 
+    missing = []
     for prompt, out in zip(inputs, output_iter):
         idx += 1
         if iterator:
@@ -209,28 +212,69 @@ def generate_responses(
         if not isinstance(out, list):
             out = [out]
 
-            if not isinstance(out, list):
-                out = [out]
-            cands = []
-            for o in out:
-                result = o["generated_text"]
-                if result.startswith(prompt):
-                    result = result[len(prompt) :]
-                cleaned = sanitize_output(result)
-                if cleaned:
-                    cands.append(cleaned)
-            responses.append(list(dict.fromkeys(cands)))
+        cands: List[str] = []
+        for o in out:
+            result = o["generated_text"]
+            if result.startswith(prompt):
+                result = result[len(prompt) :]
+            cleaned = sanitize_output(result)
+            if cleaned:
+                cands.append(cleaned)
 
-            if save_midway and next_save < len(quarter_points) and idx == quarter_points[next_save]:
-                dump_records(
-                    f"save{next_save + 1}.json",
-                    (original_inputs or inputs)[:idx],
-                    responses,
-                )
-                next_save += 1
+        uniq = list(dict.fromkeys(cands))[:num_candidates]
+        responses.append(uniq)
+        if len(uniq) < num_candidates:
+            missing.append(idx - 1)
+
+        if save_midway and next_save < len(quarter_points) and idx == quarter_points[next_save]:
+            dump_records(
+                f"save{next_save + 1}.json",
+                (original_inputs or inputs)[:idx],
+                responses,
+            )
+            next_save += 1
 
     if iterator:
         iterator.close()
+
+    attempts = 0
+    while missing and attempts < 5:
+        prompts_batch = [inputs[i] for i in missing]
+        outs = generator(
+            prompts_batch,
+            batch_size=batch_size,
+            max_new_tokens=max_new_tokens,
+            do_sample=True,
+            temperature=temperature,
+            top_p=top_p,
+            num_return_sequences=num_candidates,
+            pad_token_id=tokenizer.eos_token_id,
+        )
+        if len(prompts_batch) == 1 and not isinstance(outs[0], list):
+            outs = [outs]
+
+        new_missing = []
+        for idx_m, out_list in zip(missing, outs):
+            if not isinstance(out_list, list):
+                out_list = [out_list]
+            for o in out_list:
+                result = o["generated_text"]
+                if result.startswith(inputs[idx_m]):
+                    result = result[len(inputs[idx_m]) :]
+                cleaned = sanitize_output(result)
+                if cleaned and cleaned not in responses[idx_m]:
+                    responses[idx_m].append(cleaned)
+                if len(responses[idx_m]) >= num_candidates:
+                    break
+            if len(responses[idx_m]) < num_candidates:
+                new_missing.append(idx_m)
+        missing = new_missing
+        attempts += 1
+
+    for resp in responses:
+        if len(resp) > num_candidates:
+            del resp[num_candidates:]
+
     return responses
 
 

--- a/generate_candidates.py
+++ b/generate_candidates.py
@@ -172,37 +172,35 @@ def generate_responses(
     iterator = tqdm(total=len(inputs), desc="generating") if tqdm else None
     idx = 0
 
-    if KeyDataset is not None and Dataset is not None:
-        data = Dataset.from_dict({"text": inputs})
-        output_iter = generator(
-            KeyDataset(data, "text"),
-            batch_size=batch_size,
-            max_new_tokens=max_new_tokens,
-            do_sample=True,
-            temperature=temperature,
-            top_p=top_p,
-            num_return_sequences=num_candidates,
-            pad_token_id=tokenizer.eos_token_id,
-        )
+    def batched_outputs():
+        """Yield model outputs in ``batch_size`` chunks.
 
-    else:  # fall back to sequential batches
-        def _iter():
-            for start in range(0, len(inputs), batch_size):
-                batch = inputs[start : start + batch_size]
-                outs = generator(
-                    batch,
-                    batch_size=len(batch),
-                    max_new_tokens=max_new_tokens,
-                    do_sample=True,
-                    temperature=temperature,
-                    top_p=top_p,
-                    num_return_sequences=num_candidates,
-                    pad_token_id=tokenizer.eos_token_id,
-                )
-                for o in outs:
-                    yield o
+        ``text-generation`` pipelines sometimes ignore the provided ``batch_size``
+        when iterating over a Dataset object. To ensure consistent batching we
+        split the prompts manually regardless of whether ``datasets`` is
+        installed. This avoids extremely slow one-by-one generation when the
+        pipeline disregards ``batch_size``.
+        """
 
-        output_iter = _iter()
+        for start in range(0, len(inputs), batch_size):
+            batch = inputs[start : start + batch_size]
+            outs = generator(
+                batch,
+                batch_size=len(batch),
+                max_new_tokens=max_new_tokens,
+                do_sample=True,
+                temperature=temperature,
+                top_p=top_p,
+                num_return_sequences=num_candidates,
+                pad_token_id=tokenizer.eos_token_id,
+            )
+            # ``transformers`` returns a flat list when batch size is 1
+            if len(batch) == 1 and not isinstance(outs[0], list):
+                outs = [outs]
+            for o in outs:
+                yield o
+
+    output_iter = batched_outputs()
 
     missing = []
     for prompt, out in zip(inputs, output_iter):


### PR DESCRIPTION
## Summary
- retry missing candidates in batches instead of many single-string calls
- trim excess responses after retry loop

## Testing
- `python -m py_compile generate_candidates.py`
- `python -m py_compile generate_preference_dataset.py`


------
https://chatgpt.com/codex/tasks/task_e_68636c8c9350832ba3823d64950e21f9